### PR TITLE
fade header mosaic to black under menu

### DIFF
--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -381,7 +381,7 @@ select {
 /* Header */
 .header {
 	width: 100%;
-	background: url('/img/header.jpg');
+	background: linear-gradient(to bottom, #ffffff00, 65%, #000000aa, #000000ff), url('/img/header1.jpg');
 	background-size: cover;
 }
 
@@ -568,10 +568,11 @@ button:not(:-moz-focusring):focus > .menu__btn-title {
 		border: 0;
 		-webkit-transform: none;
 		transform: none;
+		background: none;
 	}
 
 	.menu__item {
-		border-left: 1px solid rgba(255, 255, 255, .1);
+		border-left: 0;
 	}
 }
 


### PR DESCRIPTION
Kathy requested that the mosaic image fade out towards the bottom.  I tried fading to white (with black menu text), but it I think it looks much better fading to black (with white text):

![image](https://user-images.githubusercontent.com/3355358/114655221-c735b280-9cb9-11eb-924d-5f799df10b14.png)

(Note, this also switches to header1.jpg, which had more saturated colors.)

What do you think?