### PR TITLE
fix path to search js

### DIFF
--- a/themes/mainroad/layouts/partials/search-index.html
+++ b/themes/mainroad/layouts/partials/search-index.html
@@ -29,5 +29,5 @@ window.store = {
 </script>
 <!-- Include Lunr and code for your search function,
 which you'll write in the next section -->
-<script src="/lunr.min.js"></script>
-<script src="/search.js"></script>
+<script src="/gre-website-test/lunr.min.js"></script>
+<script src="/gre-website-test/search.js"></script>


### PR DESCRIPTION
Need to prefix with /gre-website-test

We'll need to figure out how best to handle publishing to the test and live sites without having to change this sort of thing.