### PR TITLE
Keywords lighten

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,6 +64,7 @@ summaryLength = 10000
 [Params]
 twitter_cards = true
 images = ["images/landing-page-map-1.png"]
+customCSS = ["css/custom.css"]
 
 [Params.logo]
 title = "GARDENS of the ROMAN EMPIRE"

--- a/layouts/partials/widgets/taglist.html
+++ b/layouts/partials/widgets/taglist.html
@@ -1,0 +1,15 @@
+{{- $tags := .Site.Taxonomies.tags }}
+{{- if gt (len $tags) 0 }}
+<div class="widget-taglist widget">
+	<h4 class="widget__title">{{ T "tags_title" }}</h4>
+	<div class="widget__content">
+	{{- range $name, $taxonomy := $tags }}
+		{{- with $.Site.GetPage (printf "/tags/%s" $name) }}
+		<a class="widget-taglist__link widget__link" href="{{ .RelPermalink }}" title="{{ .Title }}">
+			{{- .Title -}}{{- if .Site.Params.widgets.tags_counter }} ({{ $taxonomy.Count }}){{ end -}}
+		</a>
+		{{- end }}
+	{{- end }}
+	</div>
+</div>
+{{- end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,5 +1,13 @@
 /* the styles in this file will override the theme styles */
 
+a:hover {
+  text-decoration: underline;
+}
+
+.menu__link:hover {
+  text-decoration: none;
+}
+
 .widget-taglist__link {
   text-transform: none;
   margin: 0 0.8em 0 0;

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,5 @@
+/* the styles in this file will override the theme styles */
+
+.widget-taglist__link {
+  text-transform: none;
+}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -2,4 +2,5 @@
 
 .widget-taglist__link {
   text-transform: none;
+  margin: 0 0.8em 0 0;
 }


### PR DESCRIPTION
This PR lightens up the keyword widget on the left side of each page, like this:

![image](https://user-images.githubusercontent.com/3355358/115928593-64c87900-a454-11eb-95e8-85ccf18789fd.png)
