### PR TITLE
Ostia latlon edits and new Pleiades links

### DIFF
--- a/content/province/italia/ostia/case_a_giardino.md
+++ b/content/province/italia/ostia/case_a_giardino.md
@@ -1,7 +1,7 @@
 ---
 title: "Garden Houses (Case a Giardino)"
 date: 2021-02-08T19:00:00-08:00
-latlon: [ 41.754855, 12.287656 ]
+latlon: [ 41.751911781895046, 12.28455095873102 ]
 province_id: PROVINCE_ID
 article_id: ARTICLE_ID
 author: Paola Olivanti
@@ -51,7 +51,8 @@ Ostia in ancient times, however, must have been a good deal greener and richer i
 
 ## Garden
 
-Garden Houses (Case a Giardino)
+Garden Houses (Case a Giardino) \
+[Garden Houses (Pleiades)](https://pleiades.stoa.org/places/223974298)
 
 ### Keywords
 
@@ -62,7 +63,7 @@ Garden Houses (Case a Giardino)
 
 ### Garden Description
 
-The area in which these houses are situated was laid out as a residential area in *c*.128 CE as part of the [Hadrianic](https://en.wikipedia.org/wiki/Hadrian) remodeling of Ostia (Fig. 1). It is delimited by buildings of various depths, due to the irregularity of the available space. The central area is occupied by two blocks each comprising four houses, surrounded, according to the excavators, by a garden furnished with six [fountains](http://vocab.getty.edu/page/aat/300006179) (a) (three on the west and three on the east side; they each measure 2.93x3.55 m. and have a maximum preserved height of 75 cm.) (Figs. 2, 3). The fountains had more than a purely decorative function. They seem rather to be the classic type of canopied fountain. Each was equipped with a water spout and probably with an opening for drawing water. The fountains were surrounded on three sides by a travertine border, in which a little channel for the discharge of excess water was hewn. Two rounded grooves in the channel, in front of each spout, have been interpreted as supports for vessels to rest in as they were filled with water. On the fourth side, which has no border, is an outlet for the discharge of water, which flowed into the main drain leading outside the complex.
+The area in which these houses are situated was laid out as a residential area in *c*. 128 CE as part of the [Hadrianic](https://en.wikipedia.org/wiki/Hadrian) remodeling of Ostia (Fig. 1). It is delimited by buildings of various depths, due to the irregularity of the available space. The central area is occupied by two blocks each comprising four houses, surrounded, according to the excavators, by a garden furnished with six [fountains](http://vocab.getty.edu/page/aat/300006179) (a) (three on the west and three on the east side; they each measure 2.93x3.55 m. and have a maximum preserved height of 75 cm.) (Figs. 2, 3). The fountains had more than a purely decorative function. They seem rather to be the classic type of canopied fountain. Each was equipped with a water spout and probably with an opening for drawing water. The fountains were surrounded on three sides by a travertine border, in which a little channel for the discharge of excess water was hewn. Two rounded grooves in the channel, in front of each spout, have been interpreted as supports for vessels to rest in as they were filled with water. On the fourth side, which has no border, is an outlet for the discharge of water, which flowed into the main drain leading outside the complex.
 
 A fourth fountain (b) was added on the eastern side, in the early years of the 3rd century CE. Its floor was embellished with a mosaic representing [Nilotic](https://en.wikipedia.org/wiki/Nile) scenes (3.30x2.96 m) (Fig. 4); it has been suggested that it was roofed with a pergola supported by small columns. This fountain was essentially ornamental. It would have provided *jeux d’eau* and was perhaps combined with small flower-beds or garden sculptures in the area surrounded by the mosaic border.
 
@@ -106,8 +107,7 @@ unspecified
 
 #### Pleiades ID
 
-[422995](https://pleiades.stoa.org/places/422995)
-<!-- Pleiades resource for Location (Ostia Antica), not for the individual garden -->
+[223974298](https://pleiades.stoa.org/places/223974298)
 
 #### TGN ID
 

--- a/content/province/italia/ostia/domus_dei_pesci.md
+++ b/content/province/italia/ostia/domus_dei_pesci.md
@@ -1,7 +1,7 @@
 ---
 title: "Garden beneath the House of the Fishes (Domus dei Pesci)"
 date: 2021-02-08T19:00:00-08:00
-latlon: [ 41.754855, 12.287656 ]
+latlon: [ 41.75282967075262, 12.28930212931829 ]
 province_id: PROVINCE_ID
 article_id: ARTICLE_ID
 author: Stella Falzone
@@ -50,7 +50,8 @@ Ostia in ancient times, however, must have been a good deal greener and richer i
 
 ## Garden
 
-Garden beneath the House of the Fishes (Domus dei Pesci)
+Garden beneath the House of the Fishes (Domus dei Pesci) \
+[House of the Fishes (Pleiades)](https://pleiades.stoa.org/places/223974300)
 
 ### Keywords
 
@@ -92,8 +93,7 @@ unspecified
 
 #### Pleiades ID
 
-[422995](https://pleiades.stoa.org/places/422995)
-<!-- Pleiades resource for Location (Ostia Antica), not for the individual garden -->
+[223974300](https://pleiades.stoa.org/places/223974300)
 
 #### TGN ID
 

--- a/content/province/italia/ostia/house_of_amor_and_psyche.md
+++ b/content/province/italia/ostia/house_of_amor_and_psyche.md
@@ -1,7 +1,7 @@
 ---
 title: "House of Amor and Psyche"
 date: 2021-02-08T19:00:00-08:00
-latlon: [ 41.754855, 12.287656 ]
+latlon: [ 41.7540027, 12.2860096 ]
 province_id: PROVINCE_ID
 article_id: ARTICLE_ID
 author: Elizabeth J. Shepherd
@@ -53,7 +53,8 @@ Ostia in ancient times, however, must have been a good deal greener and richer i
 
 ## Garden
 
-House of Amor and Psyche
+House of Amor and Psyche \
+[House of Amor and Psyche (Pleiades)](https://pleiades.stoa.org/places/868515126)
 
 ### Keywords
 
@@ -73,7 +74,7 @@ House of Amor and Psyche
 
 The entrance of this house (Fig. 1) (which takes its name from the statuary group found in room b) provides access to a large [portico](http://vocab.getty.edu/page/aat/300004145) (a) with four columns on marble bases, resting on a continuous marble-paneled [balustrade](http://vocab.getty.edu/page/aat/300001989) 50 cm high. To the right of the portico was an area believed to be a garden ([*viridarium*](https://en.wiktionary.org/wiki/viridarium)) (c) terminating in a [nymphaeum](http://vocab.getty.edu/page/aat/300006809). This consisted of a podium 1.10 m. high, paneled in white marble. Hewn into its front side are five deep circular niches. Four are paneled in white marble; only the central niche is panelled in green [cipollino marble](https://en.wikipedia.org/wiki/Cipollino_marble). The architectural elevation of the nymphaeum rises from this podium (Fig. 2). Over four meters high, it consists of two rectangular alternating with three semicircular niches, framed by six marble columns with [Corinthian](https://en.wikipedia.org/wiki/Corinthian_order) capitals and rectangular travertine [plinths](http://vocab.getty.edu/page/aat/300001749), from which little brick arches project. Five marble stepped gradients were placed between the bases of the columns. They formed miniature cascades: the water piped in by the lead conduit that ran along the bases of the niches flowed down over them. The water filled small rectangular basins and, flowing through [terracotta](http://vocab.getty.edu/page/aat/300010669) channels inside the podium, spouted from four outlets placed between the niches. The whole of the podium together with the stepped cascades was paneled in white marble and green *cipollino*; the upper part, by contrast, was stuccoed and adorned with a [polychrome](http://vocab.getty.edu/page/aat/300252261) [wall mosaic](http://vocab.getty.edu/page/aat/300015342). A tile-covered drain ran through the entire length of the podium.
 
-The [*viridarium*](https://en.wiktionary.org/wiki/viridarium) is the main source of light for all the rooms that face on it, including the large reception room (d) (Fig. 3). The house is a typical example of an Ostian patrician house of the early 4th century AD.
+The [*viridarium*](https://en.wiktionary.org/wiki/viridarium) is the main source of light for all the rooms that face on it, including the large reception room (d) (Fig. 3). The house is a typical example of an Ostian patrician house of the early 4th century CE.
 
 ### Figures
 
@@ -105,15 +106,14 @@ unspecified
 * M. De Vico Fallani, C. Pavolini, E. J. Shepherd, M. Pileri, "Un sogno lasciato a metà: il progetto di Michele Busiri Vici per le sistemazioni arboree e per i giardini nella zona di Ostia Antica Scavi (1939-1941)," *Bollettino d’Arte*, in press. [(worldcat)](http://www.worldcat.org/oclc/1536690)
 <!-- Bibliography for Garden Description -->
 * Giovanni Becatti, *Case ostiensi del tardo impero*, pp. 6-8. [(worldcat)](http://www.worldcat.org/oclc/899106405)
-* J. Packer, *American Journal of Archaeology* 71 (1967), pp 125-126. [(worldcat)](http://www.worldcat.org/oclc/1076135742)
+* James E. Packer, "The Domus of Cupid and Psyche in Ancient Ostia" in *American Journal of Archaeology*, Vol. 71, No. 2 (1967), pp. 125-126. [(worldcat)](http://www.worldcat.org/oclc/220836766) [(jstor)](https://www.jstor.org/stable/501994)
 * Bernard Andreae, *Am Birnbaum: Gärten und Parks im antiken Rom, in den Vesuvstädten und in Ostia*, 1996, p. 123. [(worldcat)](http://www.worldcat.org/oclc/797420782)
 * Giovanni Becatti, *Mosaici e pavimenti marmorei*, Scavi di Ostia IV, Rome, 1961. [(worldcat)](https://www.worldcat.org/title/scavi-di-ostia-iv-mosaici-e-pavimenti-marmorei/oclc/630825752&referer=brief_results)
 * E.J. Shepherd, P. Olivanti (eds), *Giardini ostiensi*, Bullettino della Commissione archeologica comunale di Roma, 109, 2008, pp. 93-97. [(worldcat)](http://www.worldcat.org/oclc/1130900997)
 
 #### Pleiades ID
 
-[422995](https://pleiades.stoa.org/places/422995)
-<!-- Pleiades resource for Location (Ostia Antica), not for the individual garden -->
+[868515126](https://pleiades.stoa.org/places/868515126)
 
 #### TGN ID
 

--- a/content/province/italia/ostia/house_of_the_bucrania.md
+++ b/content/province/italia/ostia/house_of_the_bucrania.md
@@ -1,7 +1,7 @@
 ---
 title: "House of the Bucrania"
 date: 2021-02-08T19:00:00-08:00
-latlon: [ 41.754855, 12.287656 ]
+latlon: [ 41.752743867143124, 12.286672797879733 ]
 province_id: PROVINCE_ID
 article_id: ARTICLE_ID
 author: Thomas Morard

--- a/content/province/italia/ostia/house_of_the_fortuna_annonaria.md
+++ b/content/province/italia/ostia/house_of_the_fortuna_annonaria.md
@@ -1,7 +1,7 @@
 ---
 title: "House of the Fortuna Annonaria"
 date: 2021-02-08T19:00:00-08:00
-latlon: [ 41.754855, 12.287656 ]
+latlon: [ 41.75413924799149, 12.290541242057353 ]
 province_id: PROVINCE_ID
 article_id: ARTICLE_ID
 author: Elizabeth J. Shepherd

--- a/content/province/italia/ostia/house_of_the_thunderbolt.md
+++ b/content/province/italia/ostia/house_of_the_thunderbolt.md
@@ -1,7 +1,7 @@
 ---
 title: "House of the Thunderbolt (Domus Fulminata)"
 date: 2021-02-08T19:00:00-08:00
-latlon: [ 41.754855, 12.287656 ]
+latlon: [ 41.750839672367256, 12.285040670892728 ]
 province_id: PROVINCE_ID
 article_id: ARTICLE_ID
 author: Paola Olivanti
@@ -54,7 +54,8 @@ Ostia in ancient times, however, must have been a good deal greener and richer i
 
 ## Garden
 
-House of the Thunderbolt (Domus Fulminata)
+House of the Thunderbolt (Domus Fulminata) \
+[House of the Thunderbolt (Pleiades)](https://pleiades.stoa.org/places/1554484)
 
 ### Keywords
 
@@ -116,8 +117,7 @@ The house is one of the most interesting examples of the transition from the atr
 
 #### Pleiades ID
 
-[422995](https://pleiades.stoa.org/places/422995)
-<!-- Pleiades resource for Location (Ostia Antica), not for the individual garden -->
+[1554484](https://pleiades.stoa.org/places/1554484)
 
 #### TGN ID
 

--- a/content/province/italia/ostia/house_on_via_del_tempio_rotondo.md
+++ b/content/province/italia/ostia/house_on_via_del_tempio_rotondo.md
@@ -1,7 +1,7 @@
 ---
 title: "House on Via del Tempio Rotondo"
 date: 2021-02-08T19:00:00-08:00
-latlon: [ 41.754855, 12.287656 ]
+latlon: [ 41.753312445649286, 12.288591244178454 ]
 province_id: PROVINCE_ID
 article_id: ARTICLE_ID
 author: Paola Olivanti

--- a/content/province/italia/ostia/house_with_peristyle.md
+++ b/content/province/italia/ostia/house_with_peristyle.md
@@ -1,7 +1,7 @@
 ---
 title: "House with Peristyle"
 date: 2021-02-08T19:00:00-08:00
-latlon: [ 41.754855, 12.287656 ]
+latlon: [ 41.752743867143124, 12.286672797879733 ]
 province_id: PROVINCE_ID
 article_id: ARTICLE_ID
 author: Thomas Morard

--- a/content/province/italia/ostia/insula_dei_dipinti.md
+++ b/content/province/italia/ostia/insula_dei_dipinti.md
@@ -1,7 +1,7 @@
 ---
 title: "Insula dei Dipinti"
 date: 2021-02-05T10:00:00-08:00
-latlon: [ 41.754855, 12.287656 ]
+latlon: [ 41.75511864107492, 12.287953204806119 ]
 province_id: PROVINCE_ID
 article_id: ARTICLE_ID
 author: Janet DeLaine
@@ -52,7 +52,8 @@ Ostia in ancient times, however, must have been a good deal greener and richer i
 
 ## Garden
 
-Insula dei Dipinti
+Insula dei Dipinti \
+[Insula dei Dipinti (Pleiades)](https://pleiades.stoa.org/places/841214213)
 
 ### Keywords
 
@@ -95,13 +96,12 @@ recent excavations
 * M. De Vico Fallani, C. Pavolini, E. J. Shepherd, M. Pileri, "Un sogno lasciato a metà: il progetto di Michele Busiri Vici per le sistemazioni arboree e per i giardini nella zona di Ostia Antica Scavi (1939-1941)," *Bollettino d’Arte*, in press. [(worldcat)](http://www.worldcat.org/oclc/1536690)
 <!-- Bibliography for Garden Description -->
 * *Giornale degli Scavi*, 1917, pp. 58, 69-70.
-* *Giornale degli Scavi (Notizie degli scavi di antichità)*, 1919, pp. 227-228, 251-253, 255, 263-5. [(worldcat)](http://www.worldcat.org/oclc/8340098)
+* *Giornale degli Scavi*, 1919, pp. 227-228, 251-253, 255, 263-5.
 * G. Calza, *Monumenti antichi* 26 (1920), pp. 328-330. [(worldcat)](http://www.worldcat.org/oclc/1067432688)
 
 #### Pleiades ID
 
-[422995](https://pleiades.stoa.org/places/422995)
-<!-- Pleiades resource for Location (Ostia Antica), not for the individual garden -->
+[841214213](https://pleiades.stoa.org/places/841214213)
 
 #### TGN ID
 

--- a/content/province/italia/ostia/schola_of_trajan.md
+++ b/content/province/italia/ostia/schola_of_trajan.md
@@ -1,7 +1,7 @@
 ---
 title: "Schola of Trajan"
 date: 2021-02-08T19:00:00-08:00
-latlon: [ 41.754855, 12.287656 ]
+latlon: [ 41.752743867143124, 12.286672797879733 ]
 province_id: PROVINCE_ID
 article_id: ARTICLE_ID
 author: Thomas Morard


### PR DESCRIPTION
Edited location data for Ostia; added links to newly created Pleiades place resources for Insula dei Dipindi, House of Amor and Psyche, House of the Thunderbold, Garden Houses, and House of the Fishes; some other minor edits