### PR TITLE
command-click on mac

### DIFF
--- a/layouts/partials/widgets/map.html
+++ b/layouts/partials/widgets/map.html
@@ -82,10 +82,10 @@
 
         // CTRL-click on map will copy coordinates
         L.DomEvent.addListener(map, 'click', function(e) {
-          if (! e.originalEvent.ctrlKey) return;
-          var coords = '[ ' + e.latlng.lat.toFixed(6) + ', ' + e.latlng.lng.toFixed(6) + ' ]';
-          navigator.clipboard.writeText(coords);
-          //alert('copied coordinates: ' + coords);
+          if (e.originalEvent.ctrlKey || e.originalEvent.metaKey) {
+            var coords = '[ ' + e.latlng.lat.toFixed(6) + ', ' + e.latlng.lng.toFixed(6) + ' ]';
+            navigator.clipboard.writeText(coords);
+          }
         });
       {{ else }}
         // For public website, use DARE basemap, backed up by OpenStreetMap


### PR DESCRIPTION
Listening for ctrl-click on the map (to capture coordinates when previewing locally) doesn't work on Mac, so listen for command-click as well.