### PR TITLE
project-wide CR/LF settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Added a .gitattributes file to help prevent updates merely due to CR/LF line endings on various Windows/Mac/Linux systems, based on advice from https://www.edwardthomson.com/blog/git_for_windows_line_endings.html